### PR TITLE
feature: create ManualOrderUseCase

### DIFF
--- a/src/adapters/inbound/telegram_bot/bot.py
+++ b/src/adapters/inbound/telegram_bot/bot.py
@@ -26,7 +26,7 @@ from src.domain.ports.outbound.repositories.order import (
 )
 from src.domain.use_cases.add_item import AddItemUseCase
 from src.domain.use_cases.cancel_order import CancelOrderUseCase
-from src.domain.use_cases.create_order import CreateOrderUseCase
+from src.domain.use_cases.create_goomer_order import CreateGoomerOrderUseCase
 from src.domain.use_cases.list_items import ListItemsUseCase
 from src.domain.use_cases.remove_item import RemoveItemUseCase
 from src.domain.use_cases.set_inventory_quantity import (
@@ -39,7 +39,7 @@ class ConversationState(int, Enum):
     WAITING_ADD_ITEM = 1
     WAITING_REMOVE_ITEM = 2
     WAITING_SET_INVENTORY_QUANTITY = 3
-    WAITING_CREATE_ORDER = 4
+    WAITING_CREATE_GOOMER_ORDER = 4
     WAITING_CANCEL_ORDER = 5
 
 
@@ -81,7 +81,7 @@ class TelegramBotCommandHandler:
             ],
             [
                 InlineKeyboardButton(
-                    "Registrar Pedido", callback_data="create_order"
+                    "Registrar Pedido", callback_data="create_goomer_order"
                 )
             ],
             [
@@ -131,12 +131,13 @@ class TelegramBotCommandHandler:
                 reply_markup=ForceReply(selective=True),
             )
             return ConversationState.WAITING_SET_INVENTORY_QUANTITY
-        elif query.data == "create_order":
+        elif query.data == "create_goomer_order":
             await query.message.reply_text(
-                "Você escolheu registrar um pedido. Envie os dados do pedido.",
+                "Você escolheu registrar um pedido feito pelo Goomer. "
+                "Envie os dados do pedido.",
                 reply_markup=ForceReply(selective=True),
             )
-            return ConversationState.WAITING_CREATE_ORDER
+            return ConversationState.WAITING_CREATE_GOOMER_ORDER
         elif query.data == "cancel_order":
             await query.message.reply_text(
                 "Você escolheu cancelar um pedido. Envie o ID do pedido. "
@@ -217,17 +218,17 @@ class TelegramBotCommandHandler:
         )
         return ConversationHandler.END
 
-    async def handle_create_order(
+    async def handle_create_goomer_order(
         self, update: Update, context: ContextTypes.DEFAULT_TYPE
     ) -> int:
         raw_input = update.message.text
         print(f"Raw input: {raw_input}")
 
-        create_order_use_case = CreateOrderUseCase(
+        create_goomer_order_use_case = CreateGoomerOrderUseCase(
             self.client_repository, self.item_repository, self.order_repository
         )
-        output_message = self.telegram_bot_controller.create_order(
-            raw_input, create_order_use_case
+        output_message = self.telegram_bot_controller.create_goomer_order(
+            raw_input, create_goomer_order_use_case
         )
 
         await update.message.reply_text(
@@ -279,10 +280,10 @@ class TelegramBotCommandHandler:
                         self.handle_set_inventory_quantity,
                     )
                 ],
-                ConversationState.WAITING_CREATE_ORDER: [
+                ConversationState.WAITING_CREATE_GOOMER_ORDER: [
                     MessageHandler(
                         filters.TEXT & ~filters.COMMAND,
-                        self.handle_create_order,
+                        self.handle_create_goomer_order,
                     )
                 ],
                 ConversationState.WAITING_CANCEL_ORDER: [

--- a/src/adapters/inbound/telegram_bot/controller.py
+++ b/src/adapters/inbound/telegram_bot/controller.py
@@ -12,12 +12,12 @@ from src.domain.ports.inbound.items.dtos import (
 )
 from src.domain.ports.inbound.orders.dtos import (
     CancelOrderInputDTO,
-    CreateOrderInputDTO,
+    CreateGoomerOrderInputDTO,
     OrderItemInputDTO,
 )
 from src.domain.use_cases.add_item import AddItemUseCase
 from src.domain.use_cases.cancel_order import CancelOrderUseCase
-from src.domain.use_cases.create_order import CreateOrderUseCase
+from src.domain.use_cases.create_goomer_order import CreateGoomerOrderUseCase
 from src.domain.use_cases.list_items import ListItemsUseCase
 from src.domain.use_cases.remove_item import RemoveItemUseCase
 from src.domain.use_cases.set_inventory_quantity import (
@@ -105,8 +105,8 @@ class TelegramBotController:
         return output_message
 
     @staticmethod
-    def create_order(
-        raw_input: str, create_order_use_case: CreateOrderUseCase
+    def create_goomer_order(
+        raw_input: str, create_order_use_case: CreateGoomerOrderUseCase
     ) -> str:
         raw_input_list = raw_input.split(ORDER_SECTIONS_DELIMITER)
 
@@ -121,7 +121,7 @@ class TelegramBotController:
         )
         created_at = TelegramBotController._extract_created_at(raw_input)
 
-        input_dto = CreateOrderInputDTO(
+        input_dto = CreateGoomerOrderInputDTO(
             client_name=client_name,
             external_order_id=external_order_id,
             external_created_at=created_at,

--- a/src/adapters/inbound/telegram_bot/controller.py
+++ b/src/adapters/inbound/telegram_bot/controller.py
@@ -13,11 +13,13 @@ from src.domain.ports.inbound.items.dtos import (
 from src.domain.ports.inbound.orders.dtos import (
     CancelOrderInputDTO,
     CreateGoomerOrderInputDTO,
+    CreateManualOrderInputDTO,
     OrderItemInputDTO,
 )
 from src.domain.use_cases.add_item import AddItemUseCase
 from src.domain.use_cases.cancel_order import CancelOrderUseCase
 from src.domain.use_cases.create_goomer_order import CreateGoomerOrderUseCase
+from src.domain.use_cases.create_manual_order import CreateManualOrderUseCase
 from src.domain.use_cases.list_items import ListItemsUseCase
 from src.domain.use_cases.remove_item import RemoveItemUseCase
 from src.domain.use_cases.set_inventory_quantity import (
@@ -51,8 +53,8 @@ class TelegramBotController:
 
     @staticmethod
     def add_item(raw_input: str, add_item_use_case: AddItemUseCase) -> str:
-        raw_item_name, inventory_quantity = re.split(r",(?=[^,]*$)", raw_input)
-        item_name = TelegramBotController._clean_text(raw_item_name.strip())
+        raw_item_name, inventory_quantity = raw_input.rsplit(",", 1)
+        item_name = TelegramBotController._clean_text(raw_item_name)
 
         input_dto = AddItemInputDTO(
             name=item_name, inventory_quantity=int(inventory_quantity)
@@ -76,7 +78,7 @@ class TelegramBotController:
         raw_input: str, remove_item_use_case: RemoveItemUseCase
     ) -> str:
         raw_item_name = raw_input
-        item_name = TelegramBotController._clean_text(raw_item_name.strip())
+        item_name = TelegramBotController._clean_text(raw_item_name)
 
         input_dto = RemoveItemInputDTO(item_name=item_name)
         output_dto = remove_item_use_case.execute(input_dto)
@@ -91,7 +93,7 @@ class TelegramBotController:
         set_inventory_quantity_use_case: SetInventoryQuantityUseCase,
     ) -> str:
         raw_item_name, inventory_quantity = re.split(r",(?=[^,]*$)", raw_input)
-        item_name = TelegramBotController._clean_text(raw_item_name.strip())
+        item_name = TelegramBotController._clean_text(raw_item_name)
 
         input_dto = SetInventoryQuantityInputDTO(
             item_name=item_name, inventory_quantity=int(inventory_quantity)
@@ -105,6 +107,41 @@ class TelegramBotController:
         return output_message
 
     @staticmethod
+    def create_manual_order(
+        raw_input: str, create_order_use_case: CreateManualOrderUseCase
+    ) -> str:
+        order_items = TelegramBotController._extract_manual_order_items(
+            raw_input
+        )
+
+        input_dto = CreateManualOrderInputDTO(items=order_items)
+
+        output_dto = create_order_use_case.execute(input_dto)
+        output_message = (
+            TelegramBotPresenter.format_create_manual_order_message(output_dto)
+        )
+        return output_message
+
+    @staticmethod
+    def _extract_manual_order_items(raw_input: str) -> list[OrderItemInputDTO]:
+        raw_quantity_and_order_items = raw_input.split("\n")
+
+        order_items = []
+        for raw_quantity_and_order_item in raw_quantity_and_order_items:
+            quantity, order_item = raw_quantity_and_order_item.split(" ", 1)
+            order_items.append(
+                OrderItemInputDTO(
+                    item_name=TelegramBotController._clean_text(order_item),
+                    quantity=int(quantity.strip()),
+                )
+            )
+
+        if not order_items:
+            raise ValueError("Order Items not found")
+
+        return order_items
+
+    @staticmethod
     def create_goomer_order(
         raw_input: str, create_order_use_case: CreateGoomerOrderUseCase
     ) -> str:
@@ -113,7 +150,7 @@ class TelegramBotController:
         external_order_id = TelegramBotController._extract_external_order_id(
             raw_input_list[1]
         )
-        order_items = TelegramBotController._extract_order_items(
+        order_items = TelegramBotController._extract_goomer_order_items(
             raw_input_list[2]
         )
         client_name = TelegramBotController._extract_client_name(
@@ -129,8 +166,8 @@ class TelegramBotController:
         )
 
         output_dto = create_order_use_case.execute(input_dto)
-        output_message = TelegramBotPresenter.format_create_order_message(
-            output_dto
+        output_message = (
+            TelegramBotPresenter.format_create_goomer_order_message(output_dto)
         )
         return output_message
 
@@ -144,7 +181,7 @@ class TelegramBotController:
         return int(external_order_id_match.group(1))
 
     @staticmethod
-    def _extract_order_items(raw_order_items_section: str) -> list:
+    def _extract_goomer_order_items(raw_order_items_section: str) -> list:
         raw_order_items = raw_order_items_section.split("\n")
         filtered_raw_order_items = [
             item
@@ -226,7 +263,9 @@ class TelegramBotController:
         return TelegramBotController._adjust_commas(
             TelegramBotController._remove_accents(
                 TelegramBotController._remove_asterisks(
-                    TelegramBotController._remove_multiple_spaces(input_str)
+                    TelegramBotController._remove_multiple_spaces(
+                        input_str.strip()
+                    )
                 )
             )
         ).lower()

--- a/src/adapters/inbound/telegram_bot/presenter.py
+++ b/src/adapters/inbound/telegram_bot/presenter.py
@@ -8,8 +8,9 @@ from src.domain.ports.inbound.items.dtos import (
 from src.domain.ports.inbound.orders.dtos import (
     CancelOrderItemOutputDTO,
     CancelOrderOutputDTO,
-    CreateGoomerOrderItemOutputDTO,
     CreateGoomerOrderOutputDTO,
+    CreateManualOrderOutputDTO,
+    CreateOrderItemOutputDTO,
 )
 
 CATEGORY_ITEM_NAME_MAP: dict[str, str] = {
@@ -29,17 +30,9 @@ class TelegramBotPresenter:
 
     @staticmethod
     def format_list_items_message(output_dto: ListItemsOutputDTO) -> str:
-        meat_items = []
-        chicken_items = []
-        vegan_items = []
-
-        for item in output_dto.items:
-            if '"carne"' in item.item_name or '"frango"' in item.item_name:
-                vegan_items.append(item)
-            elif "carne" in item.item_name:
-                meat_items.append(item)
-            elif "frango" in item.item_name:
-                chicken_items.append(item)
+        meat_items, chicken_items, vegan_items = (
+            TelegramBotPresenter._classify_items_by_category(output_dto.items)
+        )
 
         output_message = "Lista de Marmitas:\n"
         output_message += TelegramBotPresenter._format_category_for_list_items(
@@ -86,20 +79,45 @@ class TelegramBotPresenter:
         return output_message
 
     @staticmethod
-    def format_create_order_message(
+    def format_create_manual_order_message(
+        output_dto: CreateManualOrderOutputDTO,
+    ) -> str:
+        meat_items, chicken_items, vegan_items = (
+            TelegramBotPresenter._classify_items_by_category(
+                output_dto.order_items
+            )
+        )
+
+        output_message = "Pedido registrado com sucesso\\!\n\n"
+        output_message += f"*ID do Pedido:* {output_dto.order_id}\n"
+        output_message += "*Marmitas:*\n\n"
+
+        output_message += (
+            TelegramBotPresenter._format_category_for_order_items(
+                meat_items, "Carne"
+            )
+        )
+        output_message += (
+            TelegramBotPresenter._format_category_for_order_items(
+                chicken_items, "Frango"
+            )
+        )
+        output_message += (
+            TelegramBotPresenter._format_category_for_order_items(
+                vegan_items, "Vegana"
+            )
+        )
+        return output_message
+
+    @staticmethod
+    def format_create_goomer_order_message(
         output_dto: CreateGoomerOrderOutputDTO,
     ) -> str:
-        vegan_items = []
-        meat_items = []
-        chicken_items = []
-
-        for item in output_dto.order_items:
-            if '"carne"' in item.item_name or '"frango"' in item.item_name:
-                vegan_items.append(item)
-            elif "carne" in item.item_name:
-                meat_items.append(item)
-            elif "frango" in item.item_name:
-                chicken_items.append(item)
+        meat_items, chicken_items, vegan_items = (
+            TelegramBotPresenter._classify_items_by_category(
+                output_dto.order_items
+            )
+        )
 
         output_message = "Pedido registrado com sucesso\\!\n\n"
         output_message += f"*ID do Pedido:* {output_dto.order_id}\n"
@@ -141,7 +159,12 @@ class TelegramBotPresenter:
 
         output_message = "Pedido cancelado com sucesso\\!\n\n"
         output_message += f"*ID do Pedido:* {output_dto.order_id}\n"
-        output_message += f"*Cliente:* {output_dto.client_name.capitalize()}\n"
+
+        if output_dto.client_name:
+            output_message += (
+                f"*Cliente:* {output_dto.client_name.capitalize()}\n"
+            )
+
         output_message += "*Marmitas:*\n\n"
 
         output_message += (
@@ -163,8 +186,7 @@ class TelegramBotPresenter:
 
     @staticmethod
     def _format_category_for_order_items(
-        items: list[CreateGoomerOrderItemOutputDTO]
-        | list[CancelOrderItemOutputDTO],
+        items: list[CreateOrderItemOutputDTO] | list[CancelOrderItemOutputDTO],
         category_name: str,
     ) -> str:
         if not items:
@@ -184,3 +206,19 @@ class TelegramBotPresenter:
             output_message += f"  \\- *Novo Estoque:* {inventory_quantity}\n\n"
 
         return output_message
+
+    @staticmethod
+    def _classify_items_by_category(items):
+        meat_items = []
+        chicken_items = []
+        vegan_items = []
+
+        for item in items:
+            if '"carne"' in item.item_name or '"frango"' in item.item_name:
+                vegan_items.append(item)
+            elif "carne" in item.item_name:
+                meat_items.append(item)
+            elif "frango" in item.item_name:
+                chicken_items.append(item)
+
+        return meat_items, chicken_items, vegan_items

--- a/src/adapters/inbound/telegram_bot/presenter.py
+++ b/src/adapters/inbound/telegram_bot/presenter.py
@@ -8,8 +8,8 @@ from src.domain.ports.inbound.items.dtos import (
 from src.domain.ports.inbound.orders.dtos import (
     CancelOrderItemOutputDTO,
     CancelOrderOutputDTO,
-    CreateOrderItemOutputDTO,
-    CreateOrderOutputDTO,
+    CreateGoomerOrderItemOutputDTO,
+    CreateGoomerOrderOutputDTO,
 )
 
 CATEGORY_ITEM_NAME_MAP: dict[str, str] = {
@@ -87,7 +87,7 @@ class TelegramBotPresenter:
 
     @staticmethod
     def format_create_order_message(
-        output_dto: CreateOrderOutputDTO,
+        output_dto: CreateGoomerOrderOutputDTO,
     ) -> str:
         vegan_items = []
         meat_items = []
@@ -163,7 +163,8 @@ class TelegramBotPresenter:
 
     @staticmethod
     def _format_category_for_order_items(
-        items: list[CreateOrderItemOutputDTO] | list[CancelOrderItemOutputDTO],
+        items: list[CreateGoomerOrderItemOutputDTO]
+        | list[CancelOrderItemOutputDTO],
         category_name: str,
     ) -> str:
         if not items:

--- a/src/adapters/outbound/repositories/mongo/documents/order.py
+++ b/src/adapters/outbound/repositories/mongo/documents/order.py
@@ -25,12 +25,12 @@ from src.adapters.outbound.repositories.mongo.documents.order_item import (
 class OrderDocument(Document):
     meta: ClassVar[dict] = {"collection": "orders"}
     id = ObjectIdField(primary_key=True, default=lambda: ObjectId())
-    external_id = IntField(required=True)
-    external_created_at = StringField(required=True)
+    external_id = IntField(required=False)
+    external_created_at = StringField(required=False)
     created_at = DateTimeField(default=datetime.now)
     updated_at = DateTimeField(default=datetime.now)
     is_cancelled = BooleanField(default=False)
-    client = ReferenceField(ClientDocument, required=True)
+    client = ReferenceField(ClientDocument, required=False)
     order_items = ListField(
         ReferenceField(OrderItemDocument, reverse_delete_rule=mongoengine.PULL)
     )

--- a/src/adapters/outbound/repositories/mongo/order.py
+++ b/src/adapters/outbound/repositories/mongo/order.py
@@ -25,10 +25,11 @@ class MongoOrderRepository:
     def find_order_by_id(self, order_id: ObjectId) -> None | Order:
         document = OrderDocument.objects.with_id(order_id)
         if document:
-            client = Client(
-                id=document.client.id,
-                name=document.client.name,
-            )
+            if document.client:
+                client = Client(
+                    id=document.client.id,
+                    name=document.client.name,
+                )
             order_items = [
                 OrderItem(
                     quantity=order_item.quantity,
@@ -43,7 +44,7 @@ class MongoOrderRepository:
             return Order(
                 id=document.id,
                 external_id=document.external_id,
-                client=client,
+                client=client if document.client else None,
                 external_created_at=document.external_created_at,
                 created_at=document.created_at,
                 updated_at=document.updated_at,
@@ -53,7 +54,8 @@ class MongoOrderRepository:
         return None
 
     def save(self, order: Order) -> None:
-        client_document = ClientDocument.objects.with_id(order.client.id)
+        if order.client:
+            client_document = ClientDocument.objects.with_id(order.client.id)
 
         order_item_documents = []
         for order_item in order.order_items:
@@ -68,7 +70,7 @@ class MongoOrderRepository:
         order_document = OrderDocument(
             id=order.id,
             external_id=order.external_id,
-            client=client_document,
+            client=client_document if order.client else None,
             external_created_at=order.external_created_at,
             created_at=order.created_at,
             updated_at=order.updated_at,

--- a/src/domain/entities/order.py
+++ b/src/domain/entities/order.py
@@ -13,12 +13,12 @@ class OrderItem(BaseModel):
 
 
 class Order(Entity):
-    external_id: int
-    external_created_at: str
+    external_id: int | None
+    external_created_at: str | None
     created_at: datetime
     updated_at: datetime
     is_cancelled: bool
-    client: Client
+    client: Client | None
     order_items: list[OrderItem]
 
     def cancel(self):

--- a/src/domain/factories/order.py
+++ b/src/domain/factories/order.py
@@ -3,13 +3,13 @@ from zoneinfo import ZoneInfo
 
 from src.domain.entities.client import Client
 from src.domain.entities.order import Order, OrderItem
-from src.domain.ports.inbound.orders.dtos import CreateOrderInputDTO
+from src.domain.ports.inbound.orders.dtos import CreateGoomerOrderInputDTO
 
 
 class OrderFactory:
     @staticmethod
     def build(
-        input_dto: CreateOrderInputDTO,
+        input_dto: CreateGoomerOrderInputDTO,
         client: Client,
         order_items: list[OrderItem],
     ) -> Order:

--- a/src/domain/factories/order.py
+++ b/src/domain/factories/order.py
@@ -3,12 +3,14 @@ from zoneinfo import ZoneInfo
 
 from src.domain.entities.client import Client
 from src.domain.entities.order import Order, OrderItem
-from src.domain.ports.inbound.orders.dtos import CreateGoomerOrderInputDTO
+from src.domain.ports.inbound.orders.dtos import (
+    CreateGoomerOrderInputDTO,
+)
 
 
 class OrderFactory:
     @staticmethod
-    def build(
+    def build_from_goomer_order(
         input_dto: CreateGoomerOrderInputDTO,
         client: Client,
         order_items: list[OrderItem],
@@ -21,5 +23,20 @@ class OrderFactory:
             updated_at=now,
             is_cancelled=False,
             client=client,
+            order_items=order_items,
+        )
+
+    @staticmethod
+    def build_from_manual_order(
+        order_items: list[OrderItem],
+    ) -> Order:
+        now = datetime.now(ZoneInfo("America/Sao_Paulo"))
+        return Order(
+            external_id=None,
+            external_created_at=None,
+            client=None,
+            created_at=now,
+            updated_at=now,
+            is_cancelled=False,
             order_items=order_items,
         )

--- a/src/domain/ports/inbound/orders/dtos.py
+++ b/src/domain/ports/inbound/orders/dtos.py
@@ -14,7 +14,7 @@ class CreateGoomerOrderInputDTO(BaseModel):
     items: list[OrderItemInputDTO]
 
 
-class CreateGoomerOrderItemOutputDTO(BaseModel):
+class CreateOrderItemOutputDTO(BaseModel):
     item_name: str
     quantity: int
     inventory_quantity: int
@@ -24,7 +24,16 @@ class CreateGoomerOrderOutputDTO(BaseModel):
     order_id: ObjectIdField
     client_name: str
     external_order_id: int
-    order_items: list[CreateGoomerOrderItemOutputDTO]
+    order_items: list[CreateOrderItemOutputDTO]
+
+
+class CreateManualOrderInputDTO(BaseModel):
+    items: list[OrderItemInputDTO]
+
+
+class CreateManualOrderOutputDTO(BaseModel):
+    order_id: ObjectIdField
+    order_items: list[CreateOrderItemOutputDTO]
 
 
 class CancelOrderInputDTO(BaseModel):
@@ -39,8 +48,8 @@ class CancelOrderItemOutputDTO(BaseModel):
 
 class CancelOrderOutputDTO(BaseModel):
     order_id: ObjectIdField
-    client_name: str
-    external_order_id: int
+    client_name: str | None
+    external_order_id: int | None
     order_items: list[CancelOrderItemOutputDTO]
     is_cancelled: bool
     created_at: str

--- a/src/domain/ports/inbound/orders/dtos.py
+++ b/src/domain/ports/inbound/orders/dtos.py
@@ -7,24 +7,24 @@ class OrderItemInputDTO(BaseModel):
     quantity: int
 
 
-class CreateOrderInputDTO(BaseModel):
+class CreateGoomerOrderInputDTO(BaseModel):
     client_name: str
     external_order_id: int
     external_created_at: str
     items: list[OrderItemInputDTO]
 
 
-class CreateOrderItemOutputDTO(BaseModel):
+class CreateGoomerOrderItemOutputDTO(BaseModel):
     item_name: str
     quantity: int
     inventory_quantity: int
 
 
-class CreateOrderOutputDTO(BaseModel):
+class CreateGoomerOrderOutputDTO(BaseModel):
     order_id: ObjectIdField
     client_name: str
     external_order_id: int
-    order_items: list[CreateOrderItemOutputDTO]
+    order_items: list[CreateGoomerOrderItemOutputDTO]
 
 
 class CancelOrderInputDTO(BaseModel):

--- a/src/domain/ports/inbound/orders/ports.py
+++ b/src/domain/ports/inbound/orders/ports.py
@@ -5,6 +5,8 @@ from src.domain.ports.inbound.orders.dtos import (
     CancelOrderOutputDTO,
     CreateGoomerOrderInputDTO,
     CreateGoomerOrderOutputDTO,
+    CreateManualOrderInputDTO,
+    CreateManualOrderOutputDTO,
 )
 
 
@@ -12,6 +14,12 @@ class CreateGoomerOrderPort(Protocol):
     def execute(
         self, input_dto: CreateGoomerOrderInputDTO
     ) -> CreateGoomerOrderOutputDTO: ...
+
+
+class CreateManualOrderPort(Protocol):
+    def execute(
+        self, input_dto: CreateManualOrderInputDTO
+    ) -> CreateManualOrderOutputDTO: ...
 
 
 class CancelOrderPort(Protocol):

--- a/src/domain/ports/inbound/orders/ports.py
+++ b/src/domain/ports/inbound/orders/ports.py
@@ -3,15 +3,15 @@ from typing import Protocol
 from src.domain.ports.inbound.orders.dtos import (
     CancelOrderInputDTO,
     CancelOrderOutputDTO,
-    CreateOrderInputDTO,
-    CreateOrderOutputDTO,
+    CreateGoomerOrderInputDTO,
+    CreateGoomerOrderOutputDTO,
 )
 
 
-class CreateOrderPort(Protocol):
+class CreateGoomerOrderPort(Protocol):
     def execute(
-        self, input_dto: CreateOrderInputDTO
-    ) -> CreateOrderOutputDTO: ...
+        self, input_dto: CreateGoomerOrderInputDTO
+    ) -> CreateGoomerOrderOutputDTO: ...
 
 
 class CancelOrderPort(Protocol):

--- a/src/domain/use_cases/cancel_order.py
+++ b/src/domain/use_cases/cancel_order.py
@@ -48,7 +48,7 @@ class CancelOrderUseCase:
 
         return CancelOrderOutputDTO(
             order_id=order.id,
-            client_name=order.client.name,
+            client_name=order.client.name if order.client else None,
             external_order_id=order.external_id,
             is_cancelled=order.is_cancelled,
             created_at=datetime.strftime(

--- a/src/domain/use_cases/create_goomer_order.py
+++ b/src/domain/use_cases/create_goomer_order.py
@@ -4,9 +4,9 @@ from src.domain.entities.order import OrderItem
 from src.domain.exceptions import ItemsNotFoundByNameError
 from src.domain.factories.order import OrderFactory
 from src.domain.ports.inbound.orders.dtos import (
-    CreateOrderInputDTO,
-    CreateOrderItemOutputDTO,
-    CreateOrderOutputDTO,
+    CreateGoomerOrderInputDTO,
+    CreateGoomerOrderItemOutputDTO,
+    CreateGoomerOrderOutputDTO,
 )
 from src.domain.ports.outbound.repositories.client import (
     ClientRepositoryInterface,
@@ -17,7 +17,7 @@ from src.domain.ports.outbound.repositories.order import (
 )
 
 
-class CreateOrderUseCase:
+class CreateGoomerOrderUseCase:
     def __init__(
         self,
         client_repository: ClientRepositoryInterface,
@@ -40,7 +40,9 @@ class CreateOrderUseCase:
             missing_item_names = set(items_names_from_dto) - found_item_names
             raise ItemsNotFoundByNameError(list(missing_item_names))
 
-    def execute(self, input_dto: CreateOrderInputDTO) -> CreateOrderOutputDTO:
+    def execute(
+        self, input_dto: CreateGoomerOrderInputDTO
+    ) -> CreateGoomerOrderOutputDTO:
         client = self.client_repository.find_client_by_name(
             input_dto.client_name
         )
@@ -68,17 +70,19 @@ class CreateOrderUseCase:
             order_item = OrderItem(item=item, quantity=item_input.quantity)
             order_items.append(order_item)
 
-        order = OrderFactory.build(input_dto, client, order_items)
+        order = OrderFactory.build_from_goomer_order(
+            input_dto, client, order_items
+        )
 
         self.item_repository.save_all(items_from_repository)
         self.order_repository.save(order)
 
-        return CreateOrderOutputDTO(
+        return CreateGoomerOrderOutputDTO(
             order_id=order.id,
             client_name=client.name,
             external_order_id=order.external_id,
             order_items=[
-                CreateOrderItemOutputDTO(
+                CreateGoomerOrderItemOutputDTO(
                     item_name=order_item.item.name,
                     quantity=order_item.quantity,
                     inventory_quantity=order_item.item.inventory_quantity,

--- a/src/domain/use_cases/create_manual_order.py
+++ b/src/domain/use_cases/create_manual_order.py
@@ -1,15 +1,11 @@
-from src.domain.entities.client import Client
 from src.domain.entities.item import Item
 from src.domain.entities.order import OrderItem
 from src.domain.exceptions import ItemsNotFoundByNameError
 from src.domain.factories.order import OrderFactory
 from src.domain.ports.inbound.orders.dtos import (
-    CreateGoomerOrderInputDTO,
-    CreateGoomerOrderOutputDTO,
+    CreateManualOrderInputDTO,
+    CreateManualOrderOutputDTO,
     CreateOrderItemOutputDTO,
-)
-from src.domain.ports.outbound.repositories.client import (
-    ClientRepositoryInterface,
 )
 from src.domain.ports.outbound.repositories.item import ItemRepositoryInterface
 from src.domain.ports.outbound.repositories.order import (
@@ -17,14 +13,12 @@ from src.domain.ports.outbound.repositories.order import (
 )
 
 
-class CreateGoomerOrderUseCase:
+class CreateManualOrderUseCase:
     def __init__(
         self,
-        client_repository: ClientRepositoryInterface,
         item_repository: ItemRepositoryInterface,
         order_repository: OrderRepositoryInterface,
     ):
-        self.client_repository = client_repository
         self.item_repository = item_repository
         self.order_repository = order_repository
 
@@ -41,15 +35,8 @@ class CreateGoomerOrderUseCase:
             raise ItemsNotFoundByNameError(list(missing_item_names))
 
     def execute(
-        self, input_dto: CreateGoomerOrderInputDTO
-    ) -> CreateGoomerOrderOutputDTO:
-        client = self.client_repository.find_client_by_name(
-            input_dto.client_name
-        )
-        if not client:
-            client = Client(name=input_dto.client_name)
-            self.client_repository.save(client)
-
+        self, input_dto: CreateManualOrderInputDTO
+    ) -> CreateManualOrderOutputDTO:
         items_names_from_dto = [
             item_input.item_name for item_input in input_dto.items
         ]
@@ -70,17 +57,13 @@ class CreateGoomerOrderUseCase:
             order_item = OrderItem(item=item, quantity=item_input.quantity)
             order_items.append(order_item)
 
-        order = OrderFactory.build_from_goomer_order(
-            input_dto, client, order_items
-        )
+        order = OrderFactory.build_from_manual_order(order_items)
 
         self.item_repository.save_all(items_from_repository)
         self.order_repository.save(order)
 
-        return CreateGoomerOrderOutputDTO(
+        return CreateManualOrderOutputDTO(
             order_id=order.id,
-            client_name=client.name,
-            external_order_id=order.external_id,
             order_items=[
                 CreateOrderItemOutputDTO(
                     item_name=order_item.item.name,

--- a/tests/adapters/inbound/telegram_bot/test_controller.py
+++ b/tests/adapters/inbound/telegram_bot/test_controller.py
@@ -13,7 +13,7 @@ from src.domain.entities.item import Item
 from src.domain.entities.order import Order, OrderItem
 from src.domain.use_cases.add_item import AddItemUseCase
 from src.domain.use_cases.cancel_order import CancelOrderUseCase
-from src.domain.use_cases.create_order import CreateOrderUseCase
+from src.domain.use_cases.create_goomer_order import CreateGoomerOrderUseCase
 from src.domain.use_cases.list_items import ListItemsUseCase
 from src.domain.use_cases.remove_item import RemoveItemUseCase
 from src.domain.use_cases.set_inventory_quantity import (
@@ -183,9 +183,9 @@ class TestTelegramBotController:
         client_repository.save(test_client)
 
         # Act
-        output_message = controller.create_order(
+        output_message = controller.create_goomer_order(
             raw_input,
-            CreateOrderUseCase(
+            CreateGoomerOrderUseCase(
                 client_repository, item_repository, order_repository
             ),
         )
@@ -221,9 +221,9 @@ class TestTelegramBotController:
         client_repository.save(test_client)
 
         # Act
-        output_message = controller.create_order(
+        output_message = controller.create_goomer_order(
             raw_input,
-            CreateOrderUseCase(
+            CreateGoomerOrderUseCase(
                 client_repository, item_repository, order_repository
             ),
         )

--- a/tests/adapters/inbound/telegram_bot/test_controller.py
+++ b/tests/adapters/inbound/telegram_bot/test_controller.py
@@ -14,6 +14,7 @@ from src.domain.entities.order import Order, OrderItem
 from src.domain.use_cases.add_item import AddItemUseCase
 from src.domain.use_cases.cancel_order import CancelOrderUseCase
 from src.domain.use_cases.create_goomer_order import CreateGoomerOrderUseCase
+from src.domain.use_cases.create_manual_order import CreateManualOrderUseCase
 from src.domain.use_cases.list_items import ListItemsUseCase
 from src.domain.use_cases.remove_item import RemoveItemUseCase
 from src.domain.use_cases.set_inventory_quantity import (
@@ -226,6 +227,61 @@ class TestTelegramBotController:
             CreateGoomerOrderUseCase(
                 client_repository, item_repository, order_repository
             ),
+        )
+
+        # Assert
+        assert output_message == "Ocorreu um erro inesperado\\."
+
+    def test_create_manual_order_controller_with_success(
+        self, controller, mongo_connection
+    ):
+        # Arrange
+        raw_input = (
+            "2 pure de batata doce,hamburguer de frango e mix de legumes"
+        )
+        order_repository = MongoOrderRepository(mongo_connection)
+
+        item_repository = MongoItemRepository(mongo_connection)
+        test_item = Item(
+            name="pure de batata doce,hamburguer de frango e mix de legumes",
+            inventory_quantity=100,
+        )
+        item_repository.save(test_item)
+
+        # Act
+        output_message = controller.create_manual_order(
+            raw_input,
+            CreateManualOrderUseCase(item_repository, order_repository),
+        )
+
+        # Assert
+        assert "Pedido registrado com sucesso\\!\n\n" in output_message
+        assert "*ID do Pedido:*" in output_message
+        assert "*Marmitas:*\n\n" in output_message
+        assert "*Marmitas de Frango:*\n" in output_message
+        assert (
+            "\\- *Nome:* Pure de batata doce,hamburguer de frango"
+            " e mix de legumes" in output_message
+        )
+        assert "\\- *Quantidade no Pedido:* 2" in output_message
+        assert "\\- *Novo Estoque:* 98\n\n" in output_message
+
+    def test_create_manual_order_controller_with_error(
+        self, controller, mongo_connection
+    ):
+        # Arrange
+        raw_input = (
+            "2 pure de batata doce,hamburguer de frango e mix de legumes"
+        )
+        order_repository = MongoOrderRepository(mongo_connection)
+
+        item_repository = MongoItemRepository(mongo_connection)
+        # doesn't save the item
+
+        # Act
+        output_message = controller.create_manual_order(
+            raw_input,
+            CreateManualOrderUseCase(item_repository, order_repository),
         )
 
         # Assert

--- a/tests/domain/use_cases/test_create_goomer_order.py
+++ b/tests/domain/use_cases/test_create_goomer_order.py
@@ -7,14 +7,14 @@ from src.domain.entities.client import Client
 from src.domain.entities.item import Item
 from src.domain.exceptions import ItemsNotFoundByNameError
 from src.domain.ports.inbound.orders.dtos import (
-    CreateOrderInputDTO,
-    CreateOrderOutputDTO,
+    CreateGoomerOrderInputDTO,
+    CreateGoomerOrderOutputDTO,
     OrderItemInputDTO,
 )
-from src.domain.use_cases.create_order import CreateOrderUseCase
+from src.domain.use_cases.create_goomer_order import CreateGoomerOrderUseCase
 
 
-class TestCreateOrderUseCase:
+class TestCreateGoomerOrderUseCase:
     @pytest.fixture
     def client_repository(self):
         return Mock()
@@ -52,18 +52,17 @@ class TestCreateOrderUseCase:
         client_repository.find_client_by_name.return_value = client
         item_repository.find_items_by_names.return_value = [item_1, item_2]
 
-        input_dto = CreateOrderInputDTO(
+        input_dto = CreateGoomerOrderInputDTO(
             client_name="Tirulipa",
             external_order_id=1234,
             external_created_at="17:54",
-            created_at="2023-06-07T10:00:00",
             items=[
                 OrderItemInputDTO(item_name="Item 1", quantity=2),
                 OrderItemInputDTO(item_name="Item 2", quantity=3),
             ],
         )
 
-        use_case = CreateOrderUseCase(
+        use_case = CreateGoomerOrderUseCase(
             client_repository, item_repository, order_repository
         )
 
@@ -71,7 +70,7 @@ class TestCreateOrderUseCase:
         output_dto = use_case.execute(input_dto)
 
         # Assert
-        assert isinstance(output_dto, CreateOrderOutputDTO)
+        assert isinstance(output_dto, CreateGoomerOrderOutputDTO)
         assert output_dto.client_name == "Tirulipa"
         assert output_dto.external_order_id == 1234
         assert len(output_dto.order_items) == 2
@@ -105,15 +104,14 @@ class TestCreateOrderUseCase:
         client_repository.find_client_by_name.return_value = client
         item_repository.find_items_by_names.return_value = [item_1]
 
-        input_dto = CreateOrderInputDTO(
+        input_dto = CreateGoomerOrderInputDTO(
             client_name="Tirulipa",
             external_order_id=1234,
             external_created_at="17:54",
-            created_at="2023-06-07T10:00:00",
             items=[OrderItemInputDTO(item_name="Item 1", quantity=15)],
         )
 
-        use_case = CreateOrderUseCase(
+        use_case = CreateGoomerOrderUseCase(
             client_repository, item_repository, order_repository
         )
 
@@ -121,7 +119,7 @@ class TestCreateOrderUseCase:
         output_dto = use_case.execute(input_dto)
 
         # Assert
-        assert isinstance(output_dto, CreateOrderOutputDTO)
+        assert isinstance(output_dto, CreateGoomerOrderOutputDTO)
         assert output_dto.client_name == "Tirulipa"
         assert output_dto.external_order_id == 1234
         assert len(output_dto.order_items) == 1
@@ -143,17 +141,16 @@ class TestCreateOrderUseCase:
         client_repository.find_client_by_name.return_value = None
         item_repository.find_items_by_names.return_value = [item_1]
 
-        input_dto = CreateOrderInputDTO(
+        input_dto = CreateGoomerOrderInputDTO(
             client_name="Tirulipa Inexistente",
             external_created_at="17:54",
             external_order_id=1234,
-            created_at="2023-06-07T10:00:00",
             items=[
                 OrderItemInputDTO(item_name="Item 1", quantity=2),
             ],
         )
 
-        use_case = CreateOrderUseCase(
+        use_case = CreateGoomerOrderUseCase(
             client_repository, item_repository, order_repository
         )
 
@@ -161,7 +158,7 @@ class TestCreateOrderUseCase:
         output_dto = use_case.execute(input_dto)
 
         # Assert
-        assert isinstance(output_dto, CreateOrderOutputDTO)
+        assert isinstance(output_dto, CreateGoomerOrderOutputDTO)
         assert output_dto.client_name == "Tirulipa Inexistente"
         assert output_dto.external_order_id == 1234
         assert len(output_dto.order_items) == 1
@@ -188,15 +185,14 @@ class TestCreateOrderUseCase:
         client_repository.find_client_by_name.return_value = client
         item_repository.find_items_by_names.return_value = []
 
-        input_dto = CreateOrderInputDTO(
+        input_dto = CreateGoomerOrderInputDTO(
             client_name="Tirulipa",
             external_created_at="17:54",
             external_order_id=1234,
-            created_at="2023-06-07T10:00:00",
             items=[OrderItemInputDTO(item_name="Item 1", quantity=2)],
         )
 
-        use_case = CreateOrderUseCase(
+        use_case = CreateGoomerOrderUseCase(
             client_repository, item_repository, order_repository
         )
 

--- a/tests/domain/use_cases/test_create_manual_order.py
+++ b/tests/domain/use_cases/test_create_manual_order.py
@@ -1,0 +1,117 @@
+from unittest.mock import Mock
+
+import pytest
+
+from src.domain.entities.item import Item
+from src.domain.exceptions import ItemsNotFoundByNameError
+from src.domain.ports.inbound.orders.dtos import (
+    CreateManualOrderInputDTO,
+    CreateManualOrderOutputDTO,
+    OrderItemInputDTO,
+)
+from src.domain.use_cases.create_manual_order import CreateManualOrderUseCase
+
+
+class TestCreateManualOrderUseCase:
+    @pytest.fixture
+    def item_repository(self):
+        return Mock()
+
+    @pytest.fixture
+    def order_repository(self):
+        return Mock()
+
+    @pytest.fixture
+    def item_1(self):
+        return Item(name="Item 1", inventory_quantity=10)
+
+    @pytest.fixture
+    def item_2(self):
+        return Item(name="Item 2", inventory_quantity=5)
+
+    def test_create_manual_order_use_case_with_success(
+        self,
+        item_repository,
+        order_repository,
+        item_1,
+        item_2,
+    ):
+        # Arrange
+        item_repository.find_items_by_names.return_value = [item_1, item_2]
+
+        input_dto = CreateManualOrderInputDTO(
+            items=[
+                OrderItemInputDTO(item_name="Item 1", quantity=2),
+                OrderItemInputDTO(item_name="Item 2", quantity=3),
+            ],
+        )
+
+        use_case = CreateManualOrderUseCase(item_repository, order_repository)
+
+        # Act
+        output_dto = use_case.execute(input_dto)
+
+        # Assert
+        assert isinstance(output_dto, CreateManualOrderOutputDTO)
+        assert len(output_dto.order_items) == 2
+        assert output_dto.order_items[0].item_name == "Item 1"
+        assert output_dto.order_items[0].quantity == 2
+        assert output_dto.order_items[0].inventory_quantity == 8
+        assert output_dto.order_items[1].item_name == "Item 2"
+        assert output_dto.order_items[1].quantity == 3
+        assert output_dto.order_items[1].inventory_quantity == 2
+
+        item_repository.find_items_by_names.assert_called_once_with(
+            ["Item 1", "Item 2"]
+        )
+        item_repository.save_all.assert_called_once_with([item_1, item_2])
+
+        order_repository.save.assert_called_once()
+
+    def test_create_manual_order_use_case_negative_inventory(
+        self,
+        item_repository,
+        order_repository,
+        item_1,
+    ):
+        # Arrange
+        item_repository.find_items_by_names.return_value = [item_1]
+
+        input_dto = CreateManualOrderInputDTO(
+            items=[OrderItemInputDTO(item_name="Item 1", quantity=15)],
+        )
+
+        use_case = CreateManualOrderUseCase(item_repository, order_repository)
+
+        # Act
+        output_dto = use_case.execute(input_dto)
+
+        # Assert
+        assert isinstance(output_dto, CreateManualOrderOutputDTO)
+        assert len(output_dto.order_items) == 1
+        assert output_dto.order_items[0].item_name == "Item 1"
+        assert output_dto.order_items[0].quantity == 15
+        assert output_dto.order_items[0].inventory_quantity == -5
+
+        item_repository.save_all.assert_called_once_with([item_1])
+        order_repository.save.assert_called_once()
+
+    def test_create_order_use_case_raises_item_not_found(
+        self, item_repository, order_repository
+    ):
+        # Arrange
+        item_repository.find_items_by_names.return_value = []
+
+        input_dto = CreateManualOrderInputDTO(
+            items=[OrderItemInputDTO(item_name="Item 1", quantity=2)],
+        )
+
+        use_case = CreateManualOrderUseCase(item_repository, order_repository)
+
+        # Act & Assert
+        with pytest.raises(ItemsNotFoundByNameError) as exc_info:
+            use_case.execute(input_dto)
+        assert str(exc_info.value) == "Items not found: ['Item 1']"
+
+        item_repository.save.assert_not_called()
+        order_repository.save.assert_not_called()


### PR DESCRIPTION
1. Renomeia `CreateOrderUseCase` para `CreateGoomerOrderUseCase`
2. Cria `CreateManualOrderUseCase` para pedidos feitos manulamente (fora do Goomer): tornei o `Client` e alguns outros campos opcionais (`required=False`) para suportar esse caso de uso